### PR TITLE
Set timer.active = false before calling end_fn

### DIFF
--- a/timers.lua
+++ b/timers.lua
@@ -38,11 +38,11 @@ function update_timers ()
         if timer.step_fn then
           timer.step_fn(dt,elapsed,length,timer)
         end  
-      else
+    else
+        timer.active = false
         if timer.end_fn then
           timer.end_fn(dt,elapsed,length,timer)
         end
-        timer.active = false
       end
     end
   end


### PR DESCRIPTION
Hi, I was thinking that maybe setting a timer as inactive before calling `end_fn` could be more useful; in my case I was calling `restart_timer` (with `start_paused` === false) inside `end_fn` but the timer was not actually restarted because `timer.active` was being re-setted to false immediately after the callback call. Thank you.
